### PR TITLE
Install git lfs before checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       GRADLE_OPTS: -Dorg.gradle.jvmargs='-XX:MaxMetaspaceSize=256m' -Dorg.gradle.workers.max=4
       _JAVA_OPTIONS: -XX:ActiveProcessorCount=4 -Xmx1177m -XX:MaxMetaspaceSize=512m -XX:ErrorFile=/home/circleci/artifacts/hs_err_pid%p.log -XX:HeapDumpPath=/home/circleci/artifacts
     steps:
-      - run: sudo apt-get update -qq && apt-get install -y git-lfs
+      - run: sudo apt-get update -qq && sudo apt-get install -y git-lfs
       - run: git lfs install
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       GRADLE_OPTS: -Dorg.gradle.jvmargs='-XX:MaxMetaspaceSize=256m' -Dorg.gradle.workers.max=4
       _JAVA_OPTIONS: -XX:ActiveProcessorCount=4 -Xmx1177m -XX:MaxMetaspaceSize=512m -XX:ErrorFile=/home/circleci/artifacts/hs_err_pid%p.log -XX:HeapDumpPath=/home/circleci/artifacts
     steps:
-      - run: sudo apt-get -y install git-lfs
+      - run: sudo apt-get update -qq && apt-get install -y git-lfs
       - run: git lfs install
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@
 version: 2.1
 jobs:
   compile:
-    docker: [{ image: 'cimg/openjdk:11.0.10-node' }]
+    docker: [{ image: 'hub.docker.palantir.build/circleci/openjdk:11-jdk' }]
     resource_class: large
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
@@ -56,7 +56,7 @@ jobs:
           paths: [ project, .gradle/init.gradle ]
 
   check:
-    docker: [{ image: 'cimg/openjdk:11.0.10-node' }]
+    docker: [{ image: 'hub.docker.palantir.build/circleci/openjdk:11-jdk' }]
     resource_class: medium
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
@@ -78,7 +78,7 @@ jobs:
       - store_artifacts: { path: ~/artifacts }
 
   unit-test:
-    docker: [{ image: 'cimg/openjdk:11.0.10-node' }]
+    docker: [{ image: 'hub.docker.palantir.build/circleci/openjdk:11-jdk' }]
     resource_class: large
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
@@ -100,7 +100,7 @@ jobs:
       - store_artifacts: { path: ~/artifacts }
 
   trial-publish:
-    docker: [{ image: 'cimg/openjdk:11.0.10-node' }]
+    docker: [{ image: 'hub.docker.palantir.build/circleci/openjdk:11-jdk' }]
     resource_class: medium
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
@@ -122,7 +122,7 @@ jobs:
       - store_artifacts: { path: ~/artifacts }
 
   publish:
-    docker: [{ image: 'cimg/openjdk:11.0.10-node' }]
+    docker: [{ image: 'hub.docker.palantir.build/circleci/openjdk:11-jdk' }]
     resource_class: medium
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@
 version: 2.1
 jobs:
   compile:
-    docker: [{ image: 'hub.docker.palantir.build/circleci/openjdk:11-jdk' }]
+    docker: [{ image: 'cimg/openjdk:11.0.10-node' }]
     resource_class: large
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
@@ -56,7 +56,7 @@ jobs:
           paths: [ project, .gradle/init.gradle ]
 
   check:
-    docker: [{ image: 'hub.docker.palantir.build/circleci/openjdk:11-jdk' }]
+    docker: [{ image: 'cimg/openjdk:11.0.10-node' }]
     resource_class: medium
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
@@ -78,7 +78,7 @@ jobs:
       - store_artifacts: { path: ~/artifacts }
 
   unit-test:
-    docker: [{ image: 'hub.docker.palantir.build/circleci/openjdk:11-jdk' }]
+    docker: [{ image: 'cimg/openjdk:11.0.10-node' }]
     resource_class: large
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
@@ -100,7 +100,7 @@ jobs:
       - store_artifacts: { path: ~/artifacts }
 
   trial-publish:
-    docker: [{ image: 'hub.docker.palantir.build/circleci/openjdk:11-jdk' }]
+    docker: [{ image: 'cimg/openjdk:11.0.10-node' }]
     resource_class: medium
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
@@ -122,7 +122,7 @@ jobs:
       - store_artifacts: { path: ~/artifacts }
 
   publish:
-    docker: [{ image: 'hub.docker.palantir.build/circleci/openjdk:11-jdk' }]
+    docker: [{ image: 'cimg/openjdk:11.0.10-node' }]
     resource_class: medium
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,8 @@ jobs:
       GRADLE_OPTS: -Dorg.gradle.jvmargs='-XX:MaxMetaspaceSize=256m' -Dorg.gradle.workers.max=4
       _JAVA_OPTIONS: -XX:ActiveProcessorCount=4 -Xmx1177m -XX:MaxMetaspaceSize=512m -XX:ErrorFile=/home/circleci/artifacts/hs_err_pid%p.log -XX:HeapDumpPath=/home/circleci/artifacts
     steps:
+      - run: sudo apt-get -y install git-lfs
+      - run: git lfs install
       - checkout
       - run:
           name: delete_unrelated_tags


### PR DESCRIPTION
This PR adds an installation step to CircleCI for git lfs so that it automatically pulls large files on the `checkout` step.