### PR TITLE
Move git lfs install to after checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,8 @@ jobs:
       _JAVA_OPTIONS: -XX:ActiveProcessorCount=4 -Xmx1177m -XX:MaxMetaspaceSize=512m -XX:ErrorFile=/home/circleci/artifacts/hs_err_pid%p.log -XX:HeapDumpPath=/home/circleci/artifacts
     steps:
       - run: sudo apt-get update -qq && sudo apt-get install -y git-lfs
-      - run: git lfs install
       - checkout
+      - run: git lfs install
       - run: git lfs pull
       - run:
           name: delete_unrelated_tags


### PR DESCRIPTION
`git lfs install` needs to be run after the source code has been checked out.